### PR TITLE
eIAM (u5CMS): Redesign as external script - Updated build configures

### DIFF
--- a/vite-config/vite.universal.js
+++ b/vite-config/vite.universal.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import {fileURLToPath} from 'node:url';
+import {minify} from 'terser';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -21,7 +22,7 @@ export const inlineCssPlugin = {
       );
 
       if (jsAsset && cssContent) {
-        // Inject CSS into JS
+        // Inject CSS into JS (without minification, same as original)
         const cssInjectCode = `
 (function() {
   var style = document.createElement('style');
@@ -39,6 +40,89 @@ export const inlineCssPlugin = {
 };
 
 /**
+ * Minify js content
+ * Returns original content if catching error
+ * Same function as merge-built-files.js
+ *
+ * @see merge-built-files.js
+ * @param {string} jsContent
+ * @returns {Promise<string>}
+ */
+const minifyJsContent = async (jsContent) => {
+  // Minify the JS content
+  console.log('Minifying JavaScript code...');
+  try {
+    const minifyResult = await minify(jsContent, {
+      compress: {
+        drop_console: false,
+        drop_debugger: true,
+        sequences: true,
+        properties: true,
+        dead_code: true,
+        conditionals: true,
+        comparisons: true,
+        evaluate: true,
+        booleans: true,
+        loops: true,
+        unused: true,
+        if_return: true,
+        join_vars: true,
+        side_effects: true,
+        unsafe: false, // avoid hidden breakage
+      },
+      mangle: true,
+      format: {
+        comments: false,
+        max_line_len: 200,
+        semicolons: true,
+        wrap_func_args: true,
+      },
+    });
+
+    // Check error
+    if (minifyResult.error) {
+      console.error('Minification error:', minifyResult.error);
+      return jsContent;
+    }
+
+    // Fix for u5admin: insert a space after a closing brace if another closing brace follows immediately.
+    // This prevents '{{var}}' patterns from breaking the u5admin template parser after minification.
+    let minifiedJsContent = minifyResult.code;
+    minifiedJsContent = minifiedJsContent.replace(/}(?=})/g, '} ');
+
+    // Write log - minified completely
+    console.log('Minified JS content successfully');
+
+    // Returns minified js content with break lines
+    return minifiedJsContent;
+  } catch (e) {
+    console.error('Can not minify js content:', e);
+    return jsContent;
+  }
+};
+
+/**
+ * JavaScript minify plugin for universal build
+ * Uses same configuration as merge-built-files.js
+ */
+export const minifyJsPlugin = {
+  name: 'minify-js',
+  async generateBundle(options, bundle) {
+    // Find JS assets and minify them
+    const jsAssets = Object.keys(bundle).filter(
+      (key) => key.includes('app-universal') && key.endsWith('.js')
+    );
+
+    for (const jsAsset of jsAssets) {
+      const jsContent = bundle[jsAsset].code;
+
+      // Minify the JS content using same function as merge-built-files.js
+      bundle[jsAsset].code = await minifyJsContent(jsContent);
+    }
+  },
+};
+
+/**
  * Universal build configuration
  */
 export const universalConfig = {
@@ -51,6 +135,7 @@ export const universalConfig = {
   },
   build: {
     assetsInlineLimit: 100000000, // Inline all assets for universal build
+    minify: false, // Disable Vite's default minification, use our custom plugin
     lib: {
       entry: path.resolve(__dirname, '../src/main.universal.jsx'),
       name: 'EIamSite',
@@ -62,12 +147,18 @@ export const universalConfig = {
       output: {
         globals: {},
         inlineDynamicImports: true,
+        compact: true, // Enable compact output
         assetFileNames: () => {
           // Prevent CSS files from being emitted as separate assets
           return 'assets/[name].[hash][extname]';
         },
       },
-      plugins: [inlineCssPlugin],
+      plugins: [inlineCssPlugin, minifyJsPlugin],
     },
+    // Additional optimization options
+    target: 'es2015', // Target modern browsers for better optimization
+    sourcemap: false, // Disable sourcemaps for production build
+    reportCompressedSize: true, // Report compressed size
+    chunkSizeWarningLimit: 1000, // Increase chunk size warning limit
   },
 };


### PR DESCRIPTION
### eIAM (u5CMS): Redesign as external script - Updated build configures
- What did I do: updated universal build mode - minify with breaking line config (copied from merge-built-files.js - previous build config)
- 
<img width="2647" height="1716" alt="image" src="https://github.com/user-attachments/assets/39ab67d1-ac5d-4a1b-999b-24ddafab222c" />
