### PR TITLE
eIAM (u5cms): UI fixes

### DIFF
--- a/src/assets/css/footer.css
+++ b/src/assets/css/footer.css
@@ -1,0 +1,19 @@
+footer {
+  @apply bg-gray-pickled-bluewood !important;
+
+  border: unset !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-weight: 400 !important;
+  font-family:
+    var(--Basic-Font-Family-Font-Family, 'Noto Sans'), sans-serif !important;
+  font-size: var(--Color-Font-Header-Elements-Font-Size, 14px) !important;
+  line-height: var(--Color-Font-Header-Elements-Line-Height, 18px) !important;
+
+  .footer-container {
+    @apply container py-2 !important;
+
+    margin: 0 auto !important;
+    color: white !important;
+  }
+}

--- a/src/assets/css/global.css
+++ b/src/assets/css/global.css
@@ -9,6 +9,7 @@
 @import './search-result.css';
 @import './lang-selector.css';
 @import './accordion.css';
+@import './footer.css';
 
 @tailwind components;
 @tailwind utilities;

--- a/src/assets/css/typography.css
+++ b/src/assets/css/typography.css
@@ -39,13 +39,7 @@ article {
 
   ol,
   ul {
-    margin-top: var(--Basic-Fontsize-Paragraph-Margin-Top, 8px);
-  }
-
-  ol:has(ol, ul),
-  ul:has(ol, ul),
-  li:has(> ol, > ul) {
-    padding-bottom: var(--Basic-Fontsize-Paragraph-Margin-Top, 8px);
+    margin: var(--Basic-Fontsize-Paragraph-Margin-Top, 8px) 0;
   }
 
   a {

--- a/src/component/footer/Footer.jsx
+++ b/src/component/footer/Footer.jsx
@@ -17,23 +17,13 @@ const Footer = () => {
   }, [serverSideData]);
 
   return (
-    <footer
-      {...(hasRemovedServerElements ? {id: ELEMENT_ID.FOOTER} : {})}
-      className="!bg-gray-pickled-bluewood !py-2 !m-0 !border-0"
-      // use inline here to avoid style shifts due to old u5cms css being applied first
-      style={{
-        fontStyle: 'normal',
-        fontWeight: 400,
-        fontFamily:
-          'var(--Basic-Font-Family-Font-Family, "Noto Sans"), sans-serif',
-        fontSize: 'var(--Color-Font-Header-Elements-Font-Size, 14)',
-        lineHeight: 'var(--Color-Font-Header-Elements-Line-Height, 18px)',
-      }}
-    >
-      <div
-        className="!container !mx-auto !text-white"
-        dangerouslySetInnerHTML={{__html: footerHTML}}
-      ></div>
+    <footer {...(hasRemovedServerElements ? {id: ELEMENT_ID.FOOTER} : {})}>
+      {!!footerHTML && (
+        <div
+          className="footer-container"
+          dangerouslySetInnerHTML={{__html: footerHTML}}
+        ></div>
+      )}
     </footer>
   );
 };


### PR DESCRIPTION
## Task

**[eIAM (u5cms): UI fixes](https://trello.com/c/wUrpMSuH/1239-eiam-u5cms-ui-fixes)**

## Summary

- Fix footer text shift after page load: extracted footer styles into a dedicated `footer.css` file using `!important` to override u5cms base CSS, replacing inline styles that caused layout shift
- Footer inner content now renders conditionally (`!!footerHTML`) so the DOM is stable on first paint — eliminates the empty→populated re-render shift
- Fix unordered nested list missing margin: simplified `typography.css` to apply `margin: 8px 0` to all `ol, ul` unconditionally, removing the complex `:has()` selector logic that only added bottom padding to lists with children